### PR TITLE
import logging

### DIFF
--- a/profile/app/app/backend/profile.py
+++ b/profile/app/app/backend/profile.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import hashlib
+import logging
 import types
 import flask
 


### PR DESCRIPTION
`logging` is used on lines 101, 137, 165, and 179 without being defined.